### PR TITLE
Add type for Cain.Endpoint.Error

### DIFF
--- a/lib/cain/endpoint/error.ex
+++ b/lib/cain/endpoint/error.ex
@@ -1,4 +1,9 @@
 defmodule Cain.Endpoint.Error do
+  @type t :: %__MODULE__{
+    type: String.t(),
+    message: String.t(),
+    http_status: String.t()
+  }
   defstruct [
     :type,
     :message,


### PR DESCRIPTION
We do need the Type in our project.